### PR TITLE
fix: Extract absolute path to a system method

### DIFF
--- a/cmd/kokodoko/main.go
+++ b/cmd/kokodoko/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/kinbiko/bugsnag"
@@ -69,6 +70,12 @@ func (g *git) RepoRoot(ctx context.Context, repoPath string) (string, error) {
 		return "", err
 	}
 	return strings.ReplaceAll(output, "\n", ""), nil
+}
+
+// AbsolutePath isn't really executing a Git thing, but returns the absolute
+// path to the given relative path.
+func (g *git) AbsolutePath(relative string) (string, error) {
+	return filepath.Abs(relative)
 }
 
 func (g *git) call(ctx context.Context, cmd string) (string, error) {

--- a/kokodoko.go
+++ b/kokodoko.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/kinbiko/bugsnag"
@@ -35,6 +34,7 @@ type System interface {
 	Hash(ctx context.Context, repoPath string) (string, error)
 	// repoPath doesn't have to be the root of the repository -- any directory in the repo.
 	RepoRoot(ctx context.Context, repoPath string) (string, error)
+	AbsolutePath(relative string) (string, error)
 }
 
 // Config holds options that alters the behavior of the app.
@@ -110,7 +110,7 @@ func (k *Kokodoko) Run(ctx context.Context, args []string) (string, error) {
 	}
 	ctx = k.o11y.WithMetadatum(ctx, "candidate", "lines", lines)
 
-	absolutePath, err := filepath.Abs(candidatePath)
+	absolutePath, err := k.sys.AbsolutePath(candidatePath)
 	if err != nil {
 		return "", k.o11y.Wrap(ctx, err, "unable to get absolute filepath to '%s'", candidatePath)
 	}

--- a/kokodoko_test.go
+++ b/kokodoko_test.go
@@ -3,7 +3,6 @@ package kokodoko_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/kinbiko/bugsnag"
@@ -64,15 +63,6 @@ func TestKokodoko(t *testing.T) {
 					t.Error(err)
 				}
 				if got != tc.exp {
-					if os.Getenv("CI") == "true" {
-						// Unfortunately due to the weird way that GitHub
-						// checks out its repositories we get false negatives
-						// here.
-						// Skipping inside the test instead of at a higher
-						// level to ensure that the happy path doesn't panic at
-						// the very least.
-						t.Skip()
-					}
 					t.Errorf("expected url:\n%s\nbut got:\n%s", tc.exp, got)
 				}
 			})


### PR DESCRIPTION
The tests depended on a certain absolute path being returned, which only
makes sense on one of my developer machines.
The main logic remains the same -- strictly a testing issue.
Going to try and remove the CI guard in the tests too -- as this is
hopefully the same problem I saw in GitHub actions.