### PR TITLE
fix: Trim whitespace before returning

### DIFF
--- a/cmd/kokodoko/main.go
+++ b/cmd/kokodoko/main.go
@@ -17,7 +17,7 @@ import (
 
 // Globals are used to enable Bugsnag.
 // Must be updated per release.
-const appVersion = "0.2.1"
+const appVersion = "0.2.2"
 
 //nolint:gochecknoglobals // The following are intended to be set via ldflags, for developers.
 var (

--- a/kokodoko.go
+++ b/kokodoko.go
@@ -119,7 +119,8 @@ func (k *Kokodoko) Run(ctx context.Context, args []string) (string, error) {
 	url := fmt.Sprintf("%s/blob/%s%s%s", remoteURL, hash, filePathRelativeToGitRoot, lines)
 	k.o11y.WithMetadatum(ctx, "candidate", "url", url)
 
-	return url, nil
+	// Remove any whitespace that still exist in the string for whatever reason
+	return strings.Join(strings.Fields(url), ""), nil
 }
 
 func (k *Kokodoko) readArg(ctx context.Context, args []string) (string, string, error) {


### PR DESCRIPTION
I've been seeing random (actually, pretty consistent) newlines/spaces in the links generated from this tool. I'm going on the assumption that links to files in repos *probably* don't have whitespace in them.

Happy to revisit (revert) this fix if for some magic reason there are other users of this tool than me.